### PR TITLE
Updated AWSSDK package to version 2.3.18.0.

### DIFF
--- a/SimpleWorkflowFramework.NET/SimpleWorkflowFramework.NET.csproj
+++ b/SimpleWorkflowFramework.NET/SimpleWorkflowFramework.NET.csproj
@@ -30,10 +30,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=1.5.19.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\AWSSDK.1.5.19.0\lib\AWSSDK.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.5.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -44,6 +40,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="AWSSDK">
+      <HintPath>..\..\..\Main\packages\AWSSDK.2.3.18.0\lib\net45\AWSSDK.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions.cs" />

--- a/SimpleWorkflowFramework.NET/packages.config
+++ b/SimpleWorkflowFramework.NET/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK" version="1.5.19.0" targetFramework="net45" />
+  <package id="AWSSDK" version="2.3.18.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I encountered a runtime error when using this library in my project that uses the newest version of AWSSDK. I updated the library to use the newest AWSSDK.

Might I request an update to the NuGet package?

![screen shot 2015-02-08 at 9 31 03 pm](https://cloud.githubusercontent.com/assets/5853934/6101480/e66de79a-afd9-11e4-918b-c938c1b53db6.png)
